### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     name: Test suite
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/setup-go@v1
       with:
@@ -26,6 +27,7 @@ jobs:
     needs: test
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
     - name: Build image


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259