### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.18.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get dependencies
       run: go mod download
     - name: Run tests
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build image
       run: |
         docker build . --tag image


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
