### PR TITLE
Adding workflow to clean unfurlist GHCR manually

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,17 @@
+name: GHCR automatic clean up
+
+on: workflow_dispatch
+
+
+jobs:
+  ghcr-cleanup-job:
+      name: GHCR clean up
+      runs-on: ubuntu-latest
+      steps:
+          - name: GHCR scan and clean up
+            uses: Doist/actions/ghcr-cleanup-action/action.yml@main
+            with:
+                package_name: unfurlist
+                gh_auth_token: ${{ secrets.GH_PACKAGES_TOKEN }}
+                keep_last_number: '2'
+                dry_run: true


### PR DESCRIPTION
This PR adds a Github Action Workflow that ensures we are removing old images of unfurlist hosted in GHCR because we get charged by its usage (i.e space) and we do not need old versions of it.

For now, it gets triggered manually and with `dry_run` enabled. It will be done automatically every month once we validate that it works as expected.

Part of: https://github.com/Doist/infrastructure-backlog/issues/559