### PR TITLE
Revert "fix: Calling ghcr-cleanup action directly (#20)"

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -7,9 +7,16 @@ jobs:
       name: GHCR clean up
       runs-on: ubuntu-latest
       steps:
-          - uses: Doist/actions/ghcr-cleanup-action@main
+          - name: Checkout actions repository
+            uses: actions/checkout@v4
             with:
-              package-name: unfurlist
-              gh-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
-              keep-last-number: '2'
-              dry-run: true
+                repository: Doist/actions
+                path: ./.doist/actions
+                token: ${{ secrets.GH_REPO_TOKEN }}
+          - name: GHCR scan and clean up
+            uses: ./.doist/actions/ghcr-cleanup-action
+            with:
+                package-name: unfurlist
+                gh-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
+                keep-last-number: '2'
+                dry-run: true


### PR DESCRIPTION
This reverts commit 4a4fb8d4d008d9cf700da36bfab88cf2a0094495 because `Doist/actions` repository is private and actions in it cannot be called with `use:` statement in GitHub Workflows unless those workflows live in a private repo as well within the same GitHub Organization.

Due to this technical limitation by GitHub we have to revert to the previous method, which is the only valid option at the moment.

 