### PR TITLE
ci: Removing dry-run to ghcr-cleanup and keeping last 5 versions only

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -18,5 +18,5 @@ jobs:
             with:
                 package-name: unfurlist
                 gh-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
-                keep-last-number: '2'
-                dry-run: true
+                keep-last-number: '5'
+                dry-run: false


### PR DESCRIPTION
## Change

This PR sets `dry-run` to `false` and `keep-last-number` to `5` so the next time we manually run this workflow we will scan all versions of `unfurlist` published in GHCR and keep the latest 5 versions. All other versions available will be removed.

This PR is part of: https://github.com/Doist/infrastructure-backlog/issues/559