### PR TITLE
fix: Changing token to clean package's version to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,6 +17,6 @@ jobs:
             uses: ./.doist/actions/ghcr-cleanup-action
             with:
                 package-name: unfurlist
-                gh-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
+                gh-auth-token: ${{ secrets.GITHUB_TOKEN }}
                 keep-last-number: '5'
                 dry-run: false


### PR DESCRIPTION
This PR changes the token we use to run `ghcr-cleanup-action' to `GITHUB_TOKEN` as is the prefered method and it has admin access on this repo