### PR TITLE
ci: Automating GHCR cleanup run every month

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,6 +1,8 @@
 name: GHCR automatic clean up
 
-on: workflow_dispatch
+on: 
+  schedule:
+    - cron: 00 05 1 * * # Runs every 1st of each month at 05:00 UTC 
 
 jobs:
   ghcr-cleanup-job:


### PR DESCRIPTION
This PR automates the execution of the `ghcr clean up` workflow to run every the 1st day of each month at 05:00 

Part of: https://github.com/Doist/infrastructure-backlog/issues/559