### PR TITLE
feat: Add Accept header to outgoing requests

### DIFF
--- a/cmd/unfurlist/unfurlist.go
+++ b/cmd/unfurlist/unfurlist.go
@@ -78,6 +78,7 @@ func main() {
 	}
 	configs := []unfurlist.ConfFunc{
 		unfurlist.WithExtraHeaders(map[string]string{
+			"Accept":          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 			"Accept-Language": "en;q=1, *;q=0.5",
 		}),
 		unfurlist.WithLogger(log.New(os.Stderr, "", logFlags)),


### PR DESCRIPTION
## Summary

Adds a standard browser-like `Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8` header to all outgoing requests.

Some web servers check the `Accept` header and may serve different content, redirect, or return 406 when it's missing. This makes unfurlist's requests look more like a real browser, improving compatibility — same principle as the existing `Accept-Language` header that's already set.

## Context

Related to [Doist/Issues#19500](https://github.com/Doist/Issues/issues/19500) — URLs pasted into Todoist no longer consistently convert to titles.