### PR TITLE
Add structured video oEmbed fields

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -111,6 +111,23 @@ func WithOembedLookupFunc(fn oembed.LookupFunc) ConfFunc {
 	}
 }
 
+// WithAllowedEmbedHosts adds HTTPS hosts allowed in extracted oEmbed iframe
+// URLs. The default provider allowlist is kept. Use this when custom oEmbed
+// providers return iframe URLs outside the built-in provider set.
+func WithAllowedEmbedHosts(hosts []string) ConfFunc {
+	allowlist := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		if normalized, err := normalizeEmbedHost(host); err == nil {
+			allowlist = append(allowlist, normalized)
+		}
+	}
+	return func(h *unfurlHandler) *unfurlHandler {
+		h.embedHostAllowlist = appendUniqueEmbedHosts(h.embedHostAllowlist, defaultEmbedHostAllowlist...)
+		h.embedHostAllowlist = appendUniqueEmbedHosts(h.embedHostAllowlist, allowlist...)
+		return h
+	}
+}
+
 // WithLogger configures unfurl handler to use provided logger
 func WithLogger(l Logger) ConfFunc {
 	return func(h *unfurlHandler) *unfurlHandler {

--- a/oembed_parser.go
+++ b/oembed_parser.go
@@ -2,30 +2,202 @@ package unfurlist
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/artyom/oembed"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+	"golang.org/x/net/idna"
 )
 
-func fetchOembed(ctx context.Context, url string, fn func(context.Context, string) (*http.Response, error)) (*unfurlResult, error) {
-	resp, err := fn(ctx, url)
+var defaultEmbedHostAllowlist = []string{
+	"supercut.ai",
+	"www.loom.com",
+	"www.youtube.com",
+	"www.youtube-nocookie.com",
+	"player.vimeo.com",
+}
+
+var defaultEmbedPathPrefixes = map[string][]string{
+	"player.vimeo.com":         {"/video/"},
+	"supercut.ai":              {"/embed/"},
+	"www.loom.com":             {"/embed/"},
+	"www.youtube.com":          {"/embed/"},
+	"www.youtube-nocookie.com": {"/embed/"},
+}
+
+func fetchOembed(ctx context.Context, endpointURL string, fn func(context.Context, string) (*http.Response, error), embedHostAllowlist []string) (*unfurlResult, error) {
+	resp, err := fn(ctx, endpointURL)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	baseURL := endpointURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		baseURL = resp.Request.URL.String()
+	}
 	meta, err := oembed.FromResponse(resp)
 	if err != nil {
 		return nil, err
 	}
 	res := &unfurlResult{
-		Title:    meta.Title,
-		SiteName: meta.Provider,
-		Type:     string(meta.Type),
-		HTML:     meta.HTML,
-		Image:    meta.Thumbnail,
+		Title:        meta.Title,
+		SiteName:     meta.Provider,
+		ProviderName: meta.Provider,
+		Type:         string(meta.Type),
+		HTML:         meta.HTML,
+		Image:        meta.Thumbnail,
+		ImageWidth:   meta.ThumbnailWidth,
+		ImageHeight:  meta.ThumbnailHeight,
 	}
 	if meta.Type == oembed.TypePhoto && meta.URL != "" {
 		res.Image = meta.URL
+		res.ImageWidth = meta.Width
+		res.ImageHeight = meta.Height
+	}
+	if meta.Type == oembed.TypeVideo && meta.HTML != "" {
+		if embedURL, err := extractOembedIframeURL(meta.HTML, baseURL, embedHostAllowlist); err == nil {
+			res.EmbedURL = embedURL
+			res.EmbedWidth = meta.Width
+			res.EmbedHeight = meta.Height
+		}
 	}
 	return res, nil
+}
+
+var (
+	errNoIframe         = errors.New("oembed html has no iframe")
+	errMultipleIframes  = errors.New("oembed html has multiple iframes")
+	errUnsafeEmbedHTML  = errors.New("oembed html contains unsafe embed elements")
+	errInvalidIframeSrc = errors.New("oembed iframe src is invalid")
+	errEmbedHostDenied  = errors.New("oembed iframe host is not allowed")
+)
+
+func extractOembedIframeURL(snippet, baseURL string, embedHostAllowlist []string) (string, error) {
+	z := html.NewTokenizer(strings.NewReader(snippet))
+	var iframeSrc string
+	for {
+		switch tt := z.Next(); tt {
+		case html.ErrorToken:
+			if z.Err() == io.EOF {
+				goto finish
+			}
+			return "", z.Err()
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, hasAttr := z.TagName()
+			switch atom.Lookup(name) {
+			case atom.Script, atom.Object, atom.Embed:
+				return "", errUnsafeEmbedHTML
+			case atom.Iframe:
+				if iframeSrc != "" {
+					return "", errMultipleIframes
+				}
+				for hasAttr {
+					var k, v []byte
+					k, v, hasAttr = z.TagAttr()
+					if strings.EqualFold(string(k), "src") {
+						iframeSrc = string(v)
+					}
+				}
+			}
+		}
+	}
+
+finish:
+	if iframeSrc == "" {
+		return "", errNoIframe
+	}
+	return validateEmbedURL(iframeSrc, baseURL, embedHostAllowlist)
+}
+
+func validateEmbedURL(rawURL, baseURL string, embedHostAllowlist []string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", errInvalidIframeSrc
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", errInvalidIframeSrc
+	}
+	if !u.IsAbs() {
+		base, err := url.Parse(baseURL)
+		if err != nil || base.Scheme == "" || base.Host == "" {
+			return "", errInvalidIframeSrc
+		}
+		u = base.ResolveReference(u)
+	}
+	if u.Scheme != "https" || u.Host == "" || u.User != nil || u.Port() != "" {
+		return "", errInvalidIframeSrc
+	}
+	if pathHasDotSegment(u.EscapedPath()) {
+		return "", errInvalidIframeSrc
+	}
+	host, err := normalizeEmbedHost(u.Hostname())
+	if err != nil || host == "" {
+		return "", errInvalidIframeSrc
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return "", errInvalidIframeSrc
+	}
+	u.Host = host
+	if !slices.Contains(embedHostAllowlist, host) {
+		return "", errEmbedHostDenied
+	}
+	if !embedPathAllowed(host, u.Path) {
+		return "", errInvalidIframeSrc
+	}
+	return u.String(), nil
+}
+
+func pathHasDotSegment(path string) bool {
+	path, err := url.PathUnescape(path)
+	if err != nil {
+		return true
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func embedPathAllowed(host, path string) bool {
+	prefixes, ok := defaultEmbedPathPrefixes[host]
+	if !ok {
+		return true
+	}
+	return slices.ContainsFunc(prefixes, func(prefix string) bool {
+		return strings.HasPrefix(path, prefix)
+	})
+}
+
+func appendUniqueEmbedHosts(hosts []string, values ...string) []string {
+	for _, value := range values {
+		normalized, err := normalizeEmbedHost(value)
+		if err != nil {
+			continue
+		}
+		if !slices.Contains(hosts, normalized) {
+			hosts = append(hosts, normalized)
+		}
+	}
+	return hosts
+}
+
+func normalizeEmbedHost(host string) (string, error) {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" {
+		return "", errInvalidIframeSrc
+	}
+	if strings.EqualFold(host, "localhost") || strings.HasSuffix(host, ".localhost") {
+		return "", errInvalidIframeSrc
+	}
+	return idna.Lookup.ToASCII(host)
 }

--- a/oembed_parser_test.go
+++ b/oembed_parser_test.go
@@ -1,0 +1,356 @@
+package unfurlist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFetchOembedVideoExtractsStructuredEmbed(t *testing.T) {
+	html := `<iframe width="200" height="113" src="https://www.youtube.com/embed/MESYWwg-98I?feature=oembed"></iframe>`
+	body := mustOembedJSON(t, map[string]any{
+		"type":             "video",
+		"title":            "Hajmo Bosno Bosno",
+		"provider_name":    "YouTube",
+		"thumbnail_url":    "https://i.ytimg.com/vi/MESYWwg-98I/hqdefault.jpg",
+		"thumbnail_width":  480,
+		"thumbnail_height": 360,
+		"width":            200,
+		"height":           113,
+		"html":             html,
+	})
+	res, err := fetchOembed(context.Background(), "https://www.youtube.com/oembed", staticOembedResponse(body), defaultEmbedHostAllowlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.EmbedURL != "https://www.youtube.com/embed/MESYWwg-98I?feature=oembed" {
+		t.Fatalf("unexpected EmbedURL: %q", res.EmbedURL)
+	}
+	if res.EmbedWidth != 200 || res.EmbedHeight != 113 {
+		t.Fatalf("unexpected embed dimensions: %dx%d", res.EmbedWidth, res.EmbedHeight)
+	}
+	if res.ProviderName != "YouTube" || res.SiteName != "YouTube" {
+		t.Fatalf("unexpected provider fields: provider=%q site=%q", res.ProviderName, res.SiteName)
+	}
+	if res.Image != "https://i.ytimg.com/vi/MESYWwg-98I/hqdefault.jpg" || res.ImageWidth != 480 || res.ImageHeight != 360 {
+		t.Fatalf("unexpected thumbnail: %q %dx%d", res.Image, res.ImageWidth, res.ImageHeight)
+	}
+	if res.HTML != html {
+		t.Fatalf("unexpected raw oEmbed HTML: %q", res.HTML)
+	}
+}
+
+func TestFetchOembedVideoExtractsWrappedIframe(t *testing.T) {
+	body := mustOembedJSON(t, map[string]any{
+		"type":          "video",
+		"title":         "Quoting Demo Review",
+		"provider_name": "Supercut",
+		"width":         3652,
+		"height":        2132,
+		"html": `<div style="position: relative; padding-bottom: 58.38%">
+			<iframe src="https://supercut.ai/embed/doist/Q5JL6yXD5m7i5QjiOZ2RR9"></iframe>
+		</div>`,
+	})
+	res, err := fetchOembed(context.Background(), "https://supercut.ai/oembed", staticOembedResponse(body), defaultEmbedHostAllowlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.EmbedURL != "https://supercut.ai/embed/doist/Q5JL6yXD5m7i5QjiOZ2RR9" {
+		t.Fatalf("unexpected EmbedURL: %q", res.EmbedURL)
+	}
+}
+
+func TestFetchOembedResolvesRelativeIframeAgainstFinalResponseURL(t *testing.T) {
+	body := mustOembedJSON(t, map[string]any{
+		"type":          "video",
+		"title":         "Redirected embed",
+		"provider_name": "Example",
+		"html":          `<iframe src="/embed/one"></iframe>`,
+	})
+	fn := func(_ context.Context, endpointURL string) (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodGet, endpointURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp := testHTTPResponse(req, http.StatusOK, "application/json", body)
+		resp.Request.URL = mustParseURL(t, "https://player.example.com/oembed")
+		return resp, nil
+	}
+	res, err := fetchOembed(context.Background(), "https://example.com/oembed", fn, []string{"player.example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.EmbedURL != "https://player.example.com/embed/one" {
+		t.Fatalf("unexpected EmbedURL: %q", res.EmbedURL)
+	}
+}
+
+func TestFetchOembedRichDoesNotExtractIframe(t *testing.T) {
+	html := `<iframe src="https://www.youtube.com/embed/MESYWwg-98I"></iframe>`
+	body := mustOembedJSON(t, map[string]any{
+		"type":          "rich",
+		"title":         "Rich embed",
+		"provider_name": "Example",
+		"html":          html,
+	})
+	res, err := fetchOembed(context.Background(), "https://example.com/oembed", staticOembedResponse(body), defaultEmbedHostAllowlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.EmbedURL != "" {
+		t.Fatalf("rich oEmbed should not produce EmbedURL, got %q", res.EmbedURL)
+	}
+	if res.HTML != html {
+		t.Fatalf("unexpected raw oEmbed HTML: %q", res.HTML)
+	}
+}
+
+func TestFetchOembedVideoKeepsMetadataWhenIframeIsUnsafe(t *testing.T) {
+	html := `<script src="https://example.com/embed.js"></script>`
+	body := mustOembedJSON(t, map[string]any{
+		"type":          "video",
+		"title":         "Script-only video",
+		"provider_name": "Example",
+		"thumbnail_url": "https://example.com/thumb.jpg",
+		"html":          html,
+	})
+	res, err := fetchOembed(context.Background(), "https://example.com/oembed", staticOembedResponse(body), defaultEmbedHostAllowlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Title != "Script-only video" || res.Image != "https://example.com/thumb.jpg" || res.HTML != html {
+		t.Fatalf("unexpected metadata: %#v", res)
+	}
+	if res.EmbedURL != "" {
+		t.Fatalf("unsafe oEmbed HTML should not produce EmbedURL, got %q", res.EmbedURL)
+	}
+}
+
+func TestExtractOembedIframeURLRejectsUnsafeShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		html    string
+		wantErr error
+	}{
+		{
+			name:    "script without iframe",
+			html:    `<blockquote>hello</blockquote><script src="https://example.com/embed.js"></script>`,
+			wantErr: errUnsafeEmbedHTML,
+		},
+		{
+			name:    "no iframe",
+			html:    `<div>hello</div>`,
+			wantErr: errNoIframe,
+		},
+		{
+			name:    "multiple iframes",
+			html:    `<iframe src="https://www.youtube.com/embed/one"></iframe><iframe src="https://www.youtube.com/embed/two"></iframe>`,
+			wantErr: errMultipleIframes,
+		},
+		{
+			name:    "non-https",
+			html:    `<iframe src="http://www.youtube.com/embed/one"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "userinfo",
+			html:    `<iframe src="https://user@www.youtube.com/embed/one"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "ip host",
+			html:    `<iframe src="https://127.0.0.1/embed/one"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "localhost",
+			html:    `<iframe src="https://localhost/embed/one"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "disallowed host",
+			html:    `<iframe src="https://example.com/embed/one"></iframe>`,
+			wantErr: errEmbedHostDenied,
+		},
+		{
+			name:    "allowed host with non-embed path",
+			html:    `<iframe src="https://www.youtube.com/watch?v=MESYWwg-98I"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "allowed host with path traversal",
+			html:    `<iframe src="https://www.youtube.com/embed/../watch?v=MESYWwg-98I"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+		{
+			name:    "allowed host with encoded path traversal",
+			html:    `<iframe src="https://www.youtube.com/embed/%2e%2e/watch?v=MESYWwg-98I"></iframe>`,
+			wantErr: errInvalidIframeSrc,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := extractOembedIframeURL(tt.html, "https://www.youtube.com/oembed", defaultEmbedHostAllowlist)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("got err %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProcessURLDiscoversOembedForOpenGraphVideo(t *testing.T) {
+	oembedHTML := `<div><iframe src="https://supercut.ai/embed/doist/Q5"></iframe></div>`
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodHead {
+				return testHTTPResponse(req, http.StatusNotFound, "text/plain", ""), nil
+			}
+			switch req.URL.Host + req.URL.Path {
+			case "supercut.ai/share/doist/Q5":
+				return testHTTPResponse(req, http.StatusOK, "text/html", `<!doctype html>
+					<html>
+						<head>
+							<meta property="og:title" content="Quoting Demo Review">
+							<meta property="og:type" content="video.other">
+							<meta property="og:image" content="https://meta.supercut.ai/thumb.png">
+							<link rel="alternate" type="application/json+oembed" href="https://supercut.ai/oembed?url=https%3A%2F%2Fsupercut.ai%2Fshare%2Fdoist%2FQ5">
+						</head>
+						<body></body>
+					</html>`), nil
+			case "supercut.ai/oembed":
+				return testHTTPResponse(req, http.StatusOK, "application/json", mustOembedJSON(t, map[string]any{
+					"type":          "video",
+					"title":         "Quoting Demo Review",
+					"provider_name": "Supercut",
+					"width":         3652,
+					"height":        2132,
+					"html":          oembedHTML,
+				})), nil
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+	h := New(WithHTTPClient(client)).(*unfurlHandler)
+	res := h.processURL(context.Background(), "https://supercut.ai/share/doist/Q5")
+	if res.Title != "Quoting Demo Review" {
+		t.Fatalf("unexpected title: %q", res.Title)
+	}
+	if res.EmbedURL != "https://supercut.ai/embed/doist/Q5" {
+		t.Fatalf("unexpected EmbedURL: %q", res.EmbedURL)
+	}
+	if res.ProviderName != "Supercut" {
+		t.Fatalf("unexpected ProviderName: %q", res.ProviderName)
+	}
+	if res.HTML != "" {
+		t.Fatalf("oEmbed enrichment should not add raw HTML to OG video cards: %q", res.HTML)
+	}
+}
+
+func TestProcessURLSkipsDisallowedOembedIframeWithoutDroppingUnfurl(t *testing.T) {
+	oembedHTML := `<div><iframe src="https://example.com/embed/doist/Q5"></iframe></div>`
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodHead {
+				return testHTTPResponse(req, http.StatusNotFound, "text/plain", ""), nil
+			}
+			switch req.URL.Host + req.URL.Path {
+			case "supercut.ai/share/doist/Q5":
+				return testHTTPResponse(req, http.StatusOK, "text/html", `<!doctype html>
+					<html>
+						<head>
+							<meta property="og:title" content="Quoting Demo Review">
+							<meta property="og:type" content="video.other">
+							<meta property="og:image" content="https://meta.supercut.ai/thumb.png">
+							<link rel="alternate" type="application/json+oembed" href="https://supercut.ai/oembed?url=https%3A%2F%2Fsupercut.ai%2Fshare%2Fdoist%2FQ5">
+						</head>
+						<body></body>
+					</html>`), nil
+			case "supercut.ai/oembed":
+				return testHTTPResponse(req, http.StatusOK, "application/json", mustOembedJSON(t, map[string]any{
+					"type":          "video",
+					"title":         "Quoting Demo Review",
+					"provider_name": "Supercut",
+					"width":         3652,
+					"height":        2132,
+					"html":          oembedHTML,
+				})), nil
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+	h := New(WithHTTPClient(client)).(*unfurlHandler)
+	res := h.processURL(context.Background(), "https://supercut.ai/share/doist/Q5")
+	if res.Title != "Quoting Demo Review" || res.Type != "video.other" || res.Image != "https://meta.supercut.ai/thumb.png" {
+		t.Fatalf("unexpected unfurl result: %#v", res)
+	}
+	if res.EmbedURL != "" {
+		t.Fatalf("disallowed iframe host should not produce EmbedURL, got %q", res.EmbedURL)
+	}
+	if res.HTML != "" {
+		t.Fatalf("oEmbed enrichment should not add raw HTML to OG video cards: %q", res.HTML)
+	}
+}
+
+func TestWithAllowedEmbedHostsKeepsDefaultsAndAddsCustomHosts(t *testing.T) {
+	h := New(WithAllowedEmbedHosts([]string{"player.example.com"})).(*unfurlHandler)
+	if !slices.Contains(h.embedHostAllowlist, "www.youtube.com") {
+		t.Fatal("default YouTube embed host should remain allowed")
+	}
+	if !slices.Contains(h.embedHostAllowlist, "player.example.com") {
+		t.Fatal("custom embed host should be allowed")
+	}
+}
+
+func mustOembedJSON(t *testing.T, data map[string]any) string {
+	t.Helper()
+	body, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func staticOembedResponse(body string) func(context.Context, string) (*http.Response, error) {
+	return func(_ context.Context, endpointURL string) (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodGet, endpointURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return testHTTPResponse(req, http.StatusOK, "application/json", body), nil
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testHTTPResponse(req *http.Request, status int, contentType, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{contentType}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}

--- a/unfurlist.go
+++ b/unfurlist.go
@@ -111,29 +111,34 @@ type unfurlHandler struct {
 
 	maxResults int // max number of urls to process
 
-	fetchers []FetchFunc
-	inFlight singleflight.Group // in-flight urls processed
+	fetchers           []FetchFunc
+	inFlight           singleflight.Group // in-flight urls processed
+	embedHostAllowlist []string
 }
 
 // Result that's returned back to the client
 type unfurlResult struct {
-	URL         string `json:"url"`
-	Title       string `json:"title,omitempty"`
-	Type        string `json:"url_type,omitempty"`
-	Description string `json:"description,omitempty"`
-	HTML        string `json:"html,omitempty"`
-	SiteName    string `json:"site_name,omitempty"`
-	Favicon     string `json:"favicon,omitempty"`
-	Image       string `json:"image,omitempty"`
-	ImageWidth  int    `json:"image_width,omitempty"`
-	ImageHeight int    `json:"image_height,omitempty"`
+	URL          string `json:"url"`
+	Title        string `json:"title,omitempty"`
+	Type         string `json:"url_type,omitempty"`
+	Description  string `json:"description,omitempty"`
+	HTML         string `json:"html,omitempty"`
+	SiteName     string `json:"site_name,omitempty"`
+	ProviderName string `json:"provider_name,omitempty"`
+	Favicon      string `json:"favicon,omitempty"`
+	Image        string `json:"image,omitempty"`
+	ImageWidth   int    `json:"image_width,omitempty"`
+	ImageHeight  int    `json:"image_height,omitempty"`
+	EmbedURL     string `json:"embed_url,omitempty"`
+	EmbedWidth   int    `json:"embed_width,omitempty"`
+	EmbedHeight  int    `json:"embed_height,omitempty"`
 
 	idx int
 }
 
 func (u *unfurlResult) Empty() bool {
 	return u.URL == "" && u.Title == "" && u.Type == "" &&
-		u.Description == "" && u.Image == ""
+		u.Description == "" && u.Image == "" && u.EmbedURL == ""
 }
 
 func (u *unfurlResult) normalize() {
@@ -163,6 +168,9 @@ func (u *unfurlResult) Merge(u2 *unfurlResult) {
 	if u.SiteName == "" {
 		u.SiteName = u2.SiteName
 	}
+	if u.ProviderName == "" {
+		u.ProviderName = u2.ProviderName
+	}
 	if u.Image == "" {
 		u.Image = u2.Image
 	}
@@ -171,6 +179,42 @@ func (u *unfurlResult) Merge(u2 *unfurlResult) {
 	}
 	if u.ImageHeight == 0 {
 		u.ImageHeight = u2.ImageHeight
+	}
+	if u.EmbedURL == "" {
+		u.EmbedURL = u2.EmbedURL
+	}
+	if u.EmbedWidth == 0 {
+		u.EmbedWidth = u2.EmbedWidth
+	}
+	if u.EmbedHeight == 0 {
+		u.EmbedHeight = u2.EmbedHeight
+	}
+}
+
+func (u *unfurlResult) MergeEmbedFields(u2 *unfurlResult) {
+	if u2 == nil {
+		return
+	}
+	if u.ProviderName == "" {
+		u.ProviderName = u2.ProviderName
+	}
+	if u.Image == "" {
+		u.Image = u2.Image
+	}
+	if u.ImageWidth == 0 {
+		u.ImageWidth = u2.ImageWidth
+	}
+	if u.ImageHeight == 0 {
+		u.ImageHeight = u2.ImageHeight
+	}
+	if u.EmbedURL == "" {
+		u.EmbedURL = u2.EmbedURL
+	}
+	if u.EmbedWidth == 0 {
+		u.EmbedWidth = u2.EmbedWidth
+	}
+	if u.EmbedHeight == 0 {
+		u.EmbedHeight = u2.EmbedHeight
 	}
 }
 
@@ -195,6 +239,9 @@ func New(conf ...ConfFunc) http.Handler {
 	}
 	if h.MaxBodyChunkSize == 0 {
 		h.MaxBodyChunkSize = defaultMaxBodyChunkSize
+	}
+	if h.embedHostAllowlist == nil {
+		h.embedHostAllowlist = defaultEmbedHostAllowlist
 	}
 	if h.Log == nil {
 		h.Log = log.New(io.Discard, "", 0)
@@ -327,7 +374,7 @@ func (h *unfurlHandler) processURL(ctx context.Context, link string) *unfurlResu
 	// captchas/login pages when they see requests from non "home ISP"
 	// networks.
 	if endpoint, ok := h.oembedLookupFunc(result.URL); ok {
-		if res, err := fetchOembed(ctx, endpoint, h.httpGet); err == nil {
+		if res, err := fetchOembed(ctx, endpoint, h.httpGet, h.embedHostAllowlist); err == nil {
 			result.Merge(res)
 			goto hasMatch
 		}
@@ -368,12 +415,19 @@ func (h *unfurlHandler) processURL(ctx context.Context, link string) *unfurlResu
 		if !blocklisted(h.titleBlocklist, res.Title) {
 			result.Merge(res)
 			if result.Type != "" && result.Title != "" {
+				if result.EmbedURL == "" && isVideoType(result.Type) {
+					if endpoint, found := chunk.oembedEndpoint(h.oembedLookupFunc); found {
+						if res, err := fetchOembed(ctx, endpoint, h.httpGet, h.embedHostAllowlist); err == nil {
+							result.MergeEmbedFields(res)
+						}
+					}
+				}
 				goto hasMatch
 			}
 		}
 	}
 	if endpoint, found := chunk.oembedEndpoint(h.oembedLookupFunc); found {
-		if res, err := fetchOembed(ctx, endpoint, h.httpGet); err == nil {
+		if res, err := fetchOembed(ctx, endpoint, h.httpGet, h.embedHostAllowlist); err == nil {
 			result.Merge(res)
 			goto hasMatch
 		}
@@ -607,6 +661,10 @@ func withoutTrackingParams(rawURL string) string {
 func mcKey(s string) string {
 	sum := sha1.Sum([]byte(s))
 	return hex.EncodeToString(sum[:])
+}
+
+func isVideoType(t string) bool {
+	return t == "video" || strings.HasPrefix(t, "video.")
 }
 
 func blocklisted(blocklilst []string, title string) bool {


### PR DESCRIPTION
## Context
Adds structured video embed metadata for Comms inline video rendering, while preserving existing unfurl output for legacy consumers.

## What was changed
- Extract `embed_url` from a single safe oEmbed video iframe.
- Return `embed_width`, `embed_height`, and `provider_name` with the existing thumbnail fields.
- Validate iframe URLs server-side: HTTPS, no userinfo/ports/IPs/localhost, exact host allowlist, provider-specific embed path prefixes for built-in hosts, and no dot-segment path traversal.
- Keep raw `html` unchanged for existing consumers, and avoid adding oEmbed `html` to OG-video card enrichments.
- Discover oEmbed for OG video pages such as Supercut before returning the link card.

## Out of scope
- Spotify/audio and workspace-style embeds. Future support should be a provider allowlist/extraction change that reuses these iframe fields when the render contract is the same; no placeholder discriminator is shipped in v1.

## Local examples
Start unfurlist locally, then try:

```bash
curl -sG \
  --data-urlencode 'content=https://supercut.ai/share/doist/Q5JL6yXD5m7i5QjiOZ2RR9' \
  --data 'markdown=true' \
  http://localhost:18080 | jq
```

Sample output:

```json
[
  {
    "url": "https://supercut.ai/share/doist/Q5JL6yXD5m7i5QjiOZ2RR9",
    "title": "Quoting Demo Review",
    "url_type": "video.other",
    "site_name": "ツSupercut",
    "provider_name": "ツSupercut",
    "image": "https://meta.supercut.ai/split_screen/Q5JL6yXD5m7i5QjiOZ2RR9?version=1781523945777",
    "image_width": 1200,
    "image_height": 630,
    "embed_url": "https://supercut.ai/embed/doist/Q5JL6yXD5m7i5QjiOZ2RR9",
    "embed_width": 3652,
    "embed_height": 2132
  }
]
```

```bash
curl -sG \
  --data-urlencode 'content=https://todoist.com' \
  --data 'markdown=true' \
  http://localhost:18080 | jq
```

Sample output:

```json
[
  {
    "url": "https://todoist.com",
    "title": "Todoist | A To-Do List to Organize Your Work & Life",
    "url_type": "website",
    "description": "Trusted by 30 million people and teams. Todoist is the world's favorite task manager and to-do list app. Finally become focused, organized and calm.",
    "favicon": "https://www.todoist.com/static/favicon.ico",
    "image": "https://www.todoist.com/static/ogimages/en/og-image-home.png"
  }
]
```

## Refs
- Doist/twist-new-backend#569
- Doist/comms-web#389

## Testing
- `go test ./...`
- `go test -race ./...`
- `git diff --check`
- `doistbot review staged` once; fixed the redirect-base and cache-prefix findings, kept the explicit iframe host allowlist by design.
- GitHub Doistbot review checked; fixed the raw-HTML enrichment and path traversal findings.
